### PR TITLE
add an option to build without hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
+# Upgrading from 2.x?
+
+The 3.0 update contains breaking changes: 
+`poetry`, `mypy` and `black` are no longer distributed with `coveo-stew`.
+
+Please refer to the [upgrade guide](./README_UPGRADE.md#Upgrading from 2.x to 3.x) for more information and resolution steps. 
+
+
 # coveo-stew
 
 coveo-stew delivers a complete Continuous Integration (CI) and Continuous Delivery (CD) solution
 using [poetry](https://python-poetry.org) as its backend.
 
-
-# Features
 
 ## CI tools
 - Config-free pytest, mypy and black runners

--- a/README_UPGRADE.md
+++ b/README_UPGRADE.md
@@ -1,0 +1,59 @@
+# Upgrading from 2.x to 3.x
+
+## Poetry is not found
+
+You need to install poetry to the system and ensure it's available through the path as `poetry`.
+
+A common challenge is to make this work on a CI server.
+Feel free to use or refer to this [GitHub Action](README.md#GitHub Action) ([source](action.yml)).
+
+
+## mypy, black is not found
+
+You need to include these dependencies into your `pyproject.toml`, 
+typically in the `[tool.poetry.dev-dependencies]` section:
+
+```toml
+[tool.poetry.dev-dependencies]
+black = "*"
+mypy = "*"
+```
+
+
+## stew build fails with missing hashes
+
+Add this to your `pyproject.toml`:
+
+```toml
+[tool.stew]
+build-without-hashes = true
+```
+
+Explanation:
+
+The `stew build` command changed considerably. 
+
+In the past, we were analyzing the active virtual environment 
+and matching the information against the lock file to download the proper packages for your platform.
+
+This was a "hack", due to a bug in earlier versions of `poetry`, where the `poetry export`
+did not correctly output some constraints and caused packages to be installed on the wrong OS.
+
+This bug has been fixed, and so the hack in `coveo-stew` was removed. 
+The process is now much simpler (extra arguments removed for readability):
+
+- We call `poetry export --output temp-requirements.txt`
+- We call `pip wheel -r temp-requirements.txt --target <wheels-folder>`
+
+Unfortunately, it was reported that _some_ packages don't have a hash in the `poetry.lock` file,
+and this causes `pip wheel` to fail by design when you mix packages with hashes and with no hashes.
+
+To circumvent this, add the `build-without-hashes` switch to your configuration 
+so that `stew` adds `--without-hashes` to the `poetry export` command.
+
+probable cause: 
+- https://github.com/pypi/warehouse/pull/11775
+
+related poetry issues:
+- https://github.com/python-poetry/poetry/issues/5967
+- https://github.com/python-poetry/poetry/issues/5970

--- a/coveo_stew/metadata/stew_api.py
+++ b/coveo_stew/metadata/stew_api.py
@@ -10,10 +10,14 @@ class StewPackage:
         self,
         *,
         build: bool = False,
+        build_without_hashes: bool = False,
         pydev: bool = False,
         build_dependencies: Mapping[str, Any] = None
     ) -> None:
         self.build = build  # we won't build a project unless this is specified.
+        # poetry sometimes fail at getting hashes, in which case the export cannot work because pip will complain
+        # that some files have a hash and some don't. This fixes it.
+        self.build_without_hashes = build_without_hashes
         self.pydev = pydev  # is this a one-ring-to-bind-them-all dev environment?
         # additional build-time dependencies
         self.build_dependencies = dependencies_factory(build_dependencies)

--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -222,7 +222,11 @@ class PythonProject:
 
     def export(self) -> str:
         """Generates the content of a `requirements.txt` file based on the lock."""
-        return self.poetry_run("export", capture_output=True)
+        command = ["export"]
+        if self.options.build_without_hashes:
+            command.append("--without-hashes")
+
+        return self.poetry_run(*command, capture_output=True)
 
     def launch_continuous_integration(
         self,


### PR DESCRIPTION
There's an issue over at `pypi` that prevents `poetry` from adding hashes to the lock file.

This switch will let users bypass the issue for now. The other solution is to keep using coveo-stew 2.x which uses a completely different method to get to this.