### PR TITLE
Don't install dependencies during stew build

### DIFF
--- a/coveo_stew/commands.py
+++ b/coveo_stew/commands.py
@@ -17,7 +17,7 @@ from coveo_stew.exceptions import (
 )
 from coveo_stew.offline_publish import offline_publish
 from coveo_stew.pydev import is_pydev_project, pull_and_write_dev_requirements
-from coveo_stew.stew import PythonEnvironment, PythonProject
+from coveo_stew.stew import PythonEnvironment, PythonProject, EnvironmentCreationBehavior
 
 _COMMANDS_THAT_SKIP_INTRO_EMOJIS = ["locate"]
 
@@ -162,7 +162,7 @@ def build(
     python_environments = (
         [PythonEnvironment(python)]
         if python
-        else project.virtual_environments(create_default_if_missing=True)
+        else project.virtual_environments(create_default_if_missing=EnvironmentCreationBehavior.Empty)
     )
 
     if not directory:

--- a/coveo_stew/commands.py
+++ b/coveo_stew/commands.py
@@ -17,7 +17,11 @@ from coveo_stew.exceptions import (
 )
 from coveo_stew.offline_publish import offline_publish
 from coveo_stew.pydev import is_pydev_project, pull_and_write_dev_requirements
-from coveo_stew.stew import PythonEnvironment, PythonProject, EnvironmentCreationBehavior
+from coveo_stew.stew import (
+    EnvironmentCreationBehavior,
+    PythonEnvironment,
+    PythonProject,
+)
 
 _COMMANDS_THAT_SKIP_INTRO_EMOJIS = ["locate"]
 
@@ -162,7 +166,9 @@ def build(
     python_environments = (
         [PythonEnvironment(python)]
         if python
-        else project.virtual_environments(create_default_if_missing=EnvironmentCreationBehavior.Empty)
+        else project.virtual_environments(
+            create_default_if_missing=EnvironmentCreationBehavior.Empty
+        )
     )
 
     if not directory:

--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -10,7 +10,17 @@ from enum import Enum, auto
 from functools import cached_property
 from pathlib import Path
 from shutil import rmtree
-from typing import Any, Final, Generator, Iterator, List, Optional, Pattern, Tuple, Union
+from typing import (
+    Any,
+    Final,
+    Generator,
+    Iterator,
+    List,
+    Optional,
+    Pattern,
+    Tuple,
+    Union,
+)
 
 from coveo_functools.casing import flexfactory
 from coveo_itertools.lookups import dict_lookup
@@ -149,12 +159,18 @@ class PythonProject:
             would use by default.
         """
         if not self._virtual_environments_cache and create_default_if_missing:
-            behavior = EnvironmentCreationBehavior.Full if create_default_if_missing is True else create_default_if_missing
+            behavior = (
+                EnvironmentCreationBehavior.Full
+                if create_default_if_missing is True
+                else create_default_if_missing
+            )
             self._create_default_poetry_install(behavior)
 
         yield from self._virtual_environments_cache
 
-    def _create_default_poetry_install(self, install: EnvironmentCreationBehavior = EnvironmentCreationBehavior.Full) -> PythonEnvironment:
+    def _create_default_poetry_install(
+        self, install: EnvironmentCreationBehavior = EnvironmentCreationBehavior.Full
+    ) -> PythonEnvironment:
         """To be used only when no environments exist. Creates a default one by calling "poetry install"."""
         if install is EnvironmentCreationBehavior.Full:
             self.poetry_run("install")


### PR DESCRIPTION
Technically, all we need for `stew build` is `pip`. The way it was coded, it would call a full install with dev dependencies before building. This is not necessary and slows down builds.

With this change, if no environment exists during `stew build`, a new one will be created but dependencies will not be installed anymore.

On the current repository, this particular operation now takes 12 seconds instead of 25.