### PR TITLE
github step summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ jobs:
 See additional options and documentation in [the action file.](action.yml)
 
 
+## GitHub Action Step Report
+
+When running in a GitHub context, a step summary will automatically be generated.
+This summary can be seen in the `Summary` tab of a workflow run view in GitHub.
+
+You can disable this feature by launching `stew ci` with `--no-github-step-report`.
+
+
 # Repository Structure
 
 Please read these guides in order to learn how to organize your repository for maximum compatibility:
@@ -133,6 +141,7 @@ Options:
 - `--check <runner>` will launch only that runner. This option can be repeated.
 - `--skip <runner>` will skip that runner. Takes precedence over `--check`. This option can be repeated.
 - `--quick` skips running `poetry install --remove-untracked` before running the checks.
+- `--no-github-step-report` can be used to disable Step Report generation when running in a GitHub context.
 
 The configuration for this feature is explained in more details in the [runners](#runners-stew-ci) section.
 

--- a/coveo_stew/ci/any_runner.py
+++ b/coveo_stew/ci/any_runner.py
@@ -5,7 +5,8 @@ from coveo_styles.styles import ExitWithFailure
 from coveo_systools.filesystem import find_repo_root
 from coveo_systools.subprocess import async_check_output
 
-from coveo_stew.ci.runner import ContinuousIntegrationRunner, RunnerStatus
+from coveo_stew.ci.runner import ContinuousIntegrationRunner
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment
 from coveo_stew.exceptions import CannotLoadProject, UsageError
 from coveo_stew.stew import PythonProject

--- a/coveo_stew/ci/black_runner.py
+++ b/coveo_stew/ci/black_runner.py
@@ -1,6 +1,7 @@
 from coveo_systools.subprocess import DetailedCalledProcessError, async_check_output
 
-from coveo_stew.ci.runner import ContinuousIntegrationRunner, RunnerStatus
+from coveo_stew.ci.runner import ContinuousIntegrationRunner
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment, PythonTool
 from coveo_stew.stew import PythonProject
 

--- a/coveo_stew/ci/config.py
+++ b/coveo_stew/ci/config.py
@@ -1,16 +1,5 @@
 from itertools import cycle
-from typing import (
-    Any,
-    Dict,
-    Generator,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Dict, Generator, Iterator, List, Optional, Type, TypeVar, Union
 
 from coveo_functools.casing import flexfactory
 from coveo_styles.styles import ExitWithFailure, echo

--- a/coveo_stew/ci/config.py
+++ b/coveo_stew/ci/config.py
@@ -20,7 +20,9 @@ from coveo_stew.ci.black_runner import BlackRunner
 from coveo_stew.ci.mypy_runner import MypyRunner
 from coveo_stew.ci.poetry_runners import PoetryCheckRunner
 from coveo_stew.ci.pytest_runner import PytestRunner
-from coveo_stew.ci.runner import CIPlan, ContinuousIntegrationRunner, RunnerStatus
+from coveo_stew.ci.reporting import generate_github_step_report
+from coveo_stew.ci.runner import CIPlan, ContinuousIntegrationRunner
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.ci.stew_runners import CheckOutdatedRunner, OfflineInstallRunner
 from coveo_stew.exceptions import CannotLoadProject
 from coveo_stew.stew import PythonProject
@@ -124,9 +126,10 @@ class ContinuousIntegrationConfig:
         skips: Optional[List[str]],
         quick: bool,
         parallel: bool,
-    ) -> bool:
+        github: bool,
+    ) -> RunnerStatus:
         if self.disabled:
-            return True
+            return RunnerStatus.NotRan
 
         ci_plans = list(self._generate_ci_plans(checks=checks, skips=skips, parallel=parallel))
         for plan in ci_plans:
@@ -134,8 +137,12 @@ class ContinuousIntegrationConfig:
                 self._pyproject.install(environment=plan.environment, remove_untracked=True)
             await plan.orchestrate(auto_fix)
 
-        allowed_statuses: Tuple[RunnerStatus, ...] = (
-            (RunnerStatus.Success, RunnerStatus.NotRan) if checks else (RunnerStatus.Success,)
-        )
+        if github:
+            generate_github_step_report(ci_plans)
 
-        return all(check.status in allowed_statuses for plan in ci_plans for check in plan.checks)
+        statuses = set(check.status for plan in ci_plans for check in plan.checks)
+        for status in (RunnerStatus.Error, RunnerStatus.CheckFailed, RunnerStatus.Success):
+            if status in statuses:
+                return status
+
+        return RunnerStatus.NotRan

--- a/coveo_stew/ci/mypy_runner.py
+++ b/coveo_stew/ci/mypy_runner.py
@@ -6,7 +6,8 @@ import pkg_resources
 from coveo_styles.styles import echo
 from coveo_systools.subprocess import async_check_output
 
-from coveo_stew.ci.runner import ContinuousIntegrationRunner, RunnerStatus
+from coveo_stew.ci.runner import ContinuousIntegrationRunner
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment, PythonTool
 from coveo_stew.metadata.python_api import PythonFile
 from coveo_stew.stew import PythonProject

--- a/coveo_stew/ci/poetry_runners.py
+++ b/coveo_stew/ci/poetry_runners.py
@@ -1,6 +1,7 @@
 from coveo_systools.subprocess import async_check_output
 
-from coveo_stew.ci.runner import ContinuousIntegrationRunner, RunnerStatus
+from coveo_stew.ci.runner import ContinuousIntegrationRunner
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment, PythonTool
 
 

--- a/coveo_stew/ci/pytest_runner.py
+++ b/coveo_stew/ci/pytest_runner.py
@@ -1,6 +1,7 @@
 from coveo_systools.subprocess import async_check_output
 
-from coveo_stew.ci.runner import ContinuousIntegrationRunner, RunnerStatus
+from coveo_stew.ci.runner import ContinuousIntegrationRunner
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment, PythonTool
 from coveo_stew.stew import PythonProject
 

--- a/coveo_stew/ci/reporting.py
+++ b/coveo_stew/ci/reporting.py
@@ -4,15 +4,14 @@ import os
 import textwrap
 from collections import defaultdict
 from pathlib import Path
-from typing import Iterable, Dict, TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Dict, Iterable, List
 
 from junit_xml import TestCase, TestSuite, to_xml_report_file
 
 from coveo_stew.ci.runner_status import RunnerStatus
 
-
 if TYPE_CHECKING:
-    from coveo_stew.ci.runner import ContinuousIntegrationRunner, CIPlan
+    from coveo_stew.ci.runner import CIPlan, ContinuousIntegrationRunner
 
 
 INDENT = " " * 4
@@ -39,7 +38,7 @@ def generate_github_step_report(ci_plans: Iterable[CIPlan]) -> None:
                 RunnerStatus.NotRan: ":grey_question:",
                 RunnerStatus.Success: ":heavy_check_mark:",
                 RunnerStatus.CheckFailed: ":warning:",
-                RunnerStatus.Error: ":boom:"
+                RunnerStatus.Error: ":boom:",
             }
 
             for status, emoji in emoji_map.items():
@@ -54,8 +53,8 @@ def generate_github_step_report(ci_plans: Iterable[CIPlan]) -> None:
 
             # we add these as footnotes
             for status, comment in (
-                    (RunnerStatus.CheckFailed, f""),
-                    (RunnerStatus.Error, f" crashed"),
+                (RunnerStatus.CheckFailed, ""),
+                (RunnerStatus.Error, " crashed"),
             ):
                 for failed_check in grouped.get(status, []):
                     # footnotes e.g.: [^mypy]:
@@ -64,7 +63,11 @@ def generate_github_step_report(ci_plans: Iterable[CIPlan]) -> None:
                     )
                     markdown.append(textwrap.indent(failed_check.last_output(), INDENT))
                     if failed_check.last_exception:
-                        markdown.append(textwrap.indent(failed_check.last_exception.format(summary=True), INDENT))
+                        markdown.append(
+                            textwrap.indent(
+                                failed_check.last_exception.format(summary=True), INDENT
+                            )
+                        )
 
         with Path(output_filename).open("a") as fd:
             fd.write("\n".join(markdown))

--- a/coveo_stew/ci/reporting.py
+++ b/coveo_stew/ci/reporting.py
@@ -1,10 +1,70 @@
+from __future__ import annotations
+
+import os
+import textwrap
+from collections import defaultdict
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Dict, TYPE_CHECKING, List
 
 from junit_xml import TestCase, TestSuite, to_xml_report_file
+
+from coveo_stew.ci.runner_status import RunnerStatus
+
+
+if TYPE_CHECKING:
+    from coveo_stew.ci.runner import ContinuousIntegrationRunner, CIPlan
+
+
+INDENT = " " * 4
 
 
 def generate_report(name: str, filename: Path, test_cases: Iterable[TestCase]) -> None:
     suite = TestSuite(name, test_cases)
     with filename.open("w", encoding="utf-8") as fd:
         to_xml_report_file(fd, [suite], encoding="utf-8")
+
+
+def generate_github_step_report(ci_plans: Iterable[CIPlan]) -> None:
+    if output_filename := os.getenv("GITHUB_STEP_SUMMARY"):
+        markdown = ["# stew ci"]
+
+        for plan in ci_plans:
+            markdown.append(f"## **{plan.environment.python_version} :snake:**")
+
+            grouped: Dict[RunnerStatus, List[ContinuousIntegrationRunner]] = defaultdict(list)
+            for check in plan.checks:
+                grouped[check.status].append(check)
+
+            emoji_map = {
+                RunnerStatus.NotRan: ":grey_question:",
+                RunnerStatus.Success: ":heavy_check_mark:",
+                RunnerStatus.CheckFailed: ":warning:",
+                RunnerStatus.Error: ":boom:"
+            }
+
+            for status, emoji in emoji_map.items():
+                failure = status in (RunnerStatus.Error, RunnerStatus.CheckFailed)
+                status_line = ""
+                for check in grouped.get(status, []):
+                    # the reference leads to the footnote e.g.: [^mypy]
+                    reference = f"[^{check.name}]" if failure else ""
+                    status_line += f"{check.name} {reference}, "
+                if status_line:
+                    markdown.append(f"- {emoji} {status_line[:-2]}")
+
+            # we add these as footnotes
+            for status, comment in (
+                    (RunnerStatus.CheckFailed, f""),
+                    (RunnerStatus.Error, f" crashed"),
+            ):
+                for failed_check in grouped.get(status, []):
+                    # footnotes e.g.: [^mypy]:
+                    markdown.append(
+                        f"[^{failed_check.name}]: **{failed_check.name}{comment}:**\n{INDENT}"
+                    )
+                    markdown.append(textwrap.indent(failed_check.last_output(), INDENT))
+                    if failed_check.last_exception:
+                        markdown.append(textwrap.indent(failed_check.last_exception.format(summary=True), INDENT))
+
+        with Path(output_filename).open("a") as fd:
+            fd.write("\n".join(markdown))

--- a/coveo_stew/ci/runner.py
+++ b/coveo_stew/ci/runner.py
@@ -5,14 +5,13 @@ from functools import cached_property
 from pathlib import Path
 from typing import Callable, Coroutine, Iterable, List, Optional, Sequence, Tuple
 
-from coveo_styles.styles import ExitWithFailure, echo
+from coveo_styles.styles import echo
 from coveo_systools.subprocess import DetailedCalledProcessError
 from junit_xml import TestCase
 
 from coveo_stew.ci.reporting import generate_report
 from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment
-from coveo_stew.exceptions import CheckError
 from coveo_stew.stew import PythonProject
 
 
@@ -182,7 +181,7 @@ class CIPlan:
             RunnerStatus.Success: echo.success,
             RunnerStatus.CheckFailed: echo.warning,
             RunnerStatus.Error: echo.error,
-            RunnerStatus.NotRan: echo.outcome
+            RunnerStatus.NotRan: echo.outcome,
         }
 
         status_to_style_map[overall_status](
@@ -233,10 +232,30 @@ class Run:
                 echo.error(f"The runner {check} created an exception: ", pad_before=True)
                 echo.noise(exception, pad_after=True)
 
-            echo.error("One or more checks were not able to complete:", pad_before=True, pad_after=False, emoji="robot")
-            echo.warning("To have stew treat an exit code as a check failure instead of an error, use `check-failed-exit-codes`", item=True, pad_before=False, pad_after=False)
-            echo.warning("https://github.com/coveo/stew/blob/main/README.md#options", item=True, pad_before=False, pad_after=False)
-            echo.warning("Use the working directory and command (printed above) to invoke the command from the shell manually", item=True, pad_before=False, pad_after=True)
+            echo.error(
+                "One or more checks were not able to complete:",
+                pad_before=True,
+                pad_after=False,
+                emoji="robot",
+            )
+            echo.warning(
+                "To have stew treat an exit code as a check failure instead of an error, use `check-failed-exit-codes`",
+                item=True,
+                pad_before=False,
+                pad_after=False,
+            )
+            echo.warning(
+                "https://github.com/coveo/stew/blob/main/README.md#options",
+                item=True,
+                pad_before=False,
+                pad_after=False,
+            )
+            echo.warning(
+                "Use the working directory and command (printed above) to invoke the command from the shell manually",
+                item=True,
+                pad_before=False,
+                pad_after=True,
+            )
 
     def _report(self, check: ContinuousIntegrationRunner, feedback: bool = True) -> None:
         """Reports on a completed check."""
@@ -251,7 +270,7 @@ class Run:
 
             elif check.status is RunnerStatus.CheckFailed:
                 echo.warning(
-                    f"{check.project.package.name}: {check} reported issues:",
+                    f"{check} [{check.project.package.name}] reported issues:",
                     pad_before=True,
                     pad_after=False,
                 )

--- a/coveo_stew/ci/runner.py
+++ b/coveo_stew/ci/runner.py
@@ -1,7 +1,6 @@
 import asyncio
 from abc import abstractmethod
 from dataclasses import dataclass
-from enum import Enum, auto
 from functools import cached_property
 from pathlib import Path
 from typing import Callable, Coroutine, Iterable, List, Optional, Sequence, Tuple
@@ -11,19 +10,10 @@ from coveo_systools.subprocess import DetailedCalledProcessError
 from junit_xml import TestCase
 
 from coveo_stew.ci.reporting import generate_report
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment
 from coveo_stew.exceptions import CheckError
 from coveo_stew.stew import PythonProject
-
-
-class RunnerStatus(Enum):
-    NotRan = auto()
-    Success = auto()
-    CheckFailed = auto()
-    Error = auto()
-
-    def __str__(self) -> str:
-        return self.name
 
 
 class ContinuousIntegrationRunner:
@@ -48,7 +38,8 @@ class ContinuousIntegrationRunner:
     async def launch(
         self, environment: PythonEnvironment = None, *extra_args: str, auto_fix: bool = False
     ) -> "ContinuousIntegrationRunner":
-        """Launch the runner's checks. Will raise on unhandled exceptions.
+        """
+        Launch the runner's checks.
         Returns self for convenience with asyncio gather/as_completed/etc.
         """
         self._last_output.clear()
@@ -56,13 +47,13 @@ class ContinuousIntegrationRunner:
         try:
             self.status = await self._launch(environment, *extra_args)
         except DetailedCalledProcessError as exception:
-            if exception.returncode not in self.check_failed_exit_codes:
+            if exception.returncode in self.check_failed_exit_codes:
+                self.status = RunnerStatus.CheckFailed
+            else:
                 self.status = RunnerStatus.Error
                 self._last_exception = exception
-                raise
             self._last_output.extend(exception.decode_output().split("\n"))
             self._last_output.extend(exception.decode_stderr().split("\n"))
-            self.status = RunnerStatus.CheckFailed
 
         if all((auto_fix, self.supports_auto_fix, self.status == RunnerStatus.CheckFailed)):
             echo.noise("Errors founds; launching auto-fix routine.")
@@ -99,10 +90,10 @@ class ContinuousIntegrationRunner:
         """Echo the failures of the last run to the user. If there was no failure, do nothing."""
         if not self._last_output:
             return
-        echo.error(self.last_output())
+        echo.noise(self.last_output(), pad_after=True)
 
     def last_output(self) -> str:
-        return "\n".join(self._last_output)
+        return "\n".join(self._last_output).strip()
 
     @property
     def last_exception(self) -> Optional[DetailedCalledProcessError]:
@@ -186,22 +177,17 @@ class CIPlan:
             await run.run_and_report(parallel=self.parallel)
 
         overall_status = get_overall_run_status(*runs)
-        echo.success(
+
+        status_to_style_map = {
+            RunnerStatus.Success: echo.success,
+            RunnerStatus.CheckFailed: echo.warning,
+            RunnerStatus.Error: echo.error,
+            RunnerStatus.NotRan: echo.outcome
+        }
+
+        status_to_style_map[overall_status](
             f"The CI run for {self.environment.pretty_python_version} completed with status: {overall_status}"
         )
-
-        if exceptions := [exception for run in runs for exception in run.exceptions]:
-            raise ExitWithFailure(
-                suggestions=(
-                    "If a command should be treated as a check failure, specify `check-failed-exit-codes`",
-                    "Reference: https://github.com/coveo/stew/blob/main/README.md#options)",
-                    "Try the commands in a shell to troubleshoot them faster.",
-                ),
-                failures=(
-                    f"\n------- [{runner} failed unexpectedly] -------\n\n{str(ex)}\n"
-                    for runner, ex in exceptions
-                ),
-            ) from CheckError("Unexpected errors occurred when launching external processes.")
 
 
 @dataclass
@@ -244,8 +230,13 @@ class Run:
 
         if self.exceptions:
             for check, exception in self.exceptions:
-                echo.warning(f"The runner {check} created an exception: ", pad_before=True)
+                echo.error(f"The runner {check} created an exception: ", pad_before=True)
                 echo.noise(exception, pad_after=True)
+
+            echo.error("One or more checks were not able to complete:", pad_before=True, pad_after=False, emoji="robot")
+            echo.warning("To have stew treat an exit code as a check failure instead of an error, use `check-failed-exit-codes`", item=True, pad_before=False, pad_after=False)
+            echo.warning("https://github.com/coveo/stew/blob/main/README.md#options", item=True, pad_before=False, pad_after=False)
+            echo.warning("Use the working directory and command (printed above) to invoke the command from the shell manually", item=True, pad_before=False, pad_after=True)
 
     def _report(self, check: ContinuousIntegrationRunner, feedback: bool = True) -> None:
         """Reports on a completed check."""
@@ -261,7 +252,7 @@ class Run:
             elif check.status is RunnerStatus.CheckFailed:
                 echo.warning(
                     f"{check.project.package.name}: {check} reported issues:",
-                    pad_before=False,
+                    pad_before=True,
                     pad_after=False,
                 )
                 check.echo_last_failures()

--- a/coveo_stew/ci/runner_status.py
+++ b/coveo_stew/ci/runner_status.py
@@ -1,0 +1,11 @@
+from enum import Enum, auto
+
+
+class RunnerStatus(Enum):
+    NotRan = auto()
+    Success = auto()
+    CheckFailed = auto()
+    Error = auto()
+
+    def __str__(self) -> str:
+        return self.name

--- a/coveo_stew/ci/stew_runners.py
+++ b/coveo_stew/ci/stew_runners.py
@@ -1,7 +1,6 @@
 import asyncio
 import shutil
 import tempfile
-import time
 from pathlib import Path
 
 from coveo_styles.styles import echo
@@ -62,6 +61,8 @@ class OfflineInstallRunner(ContinuousIntegrationRunner):
             try:
                 shutil.rmtree(temporary_folder)
             except PermissionError:
-                echo.warning(f"The temporary folder for this check could not be deleted: {temporary_folder}")
+                echo.warning(
+                    f"The temporary folder for this check could not be deleted: {temporary_folder}"
+                )
 
         return RunnerStatus.Success

--- a/coveo_stew/ci/stew_runners.py
+++ b/coveo_stew/ci/stew_runners.py
@@ -1,11 +1,15 @@
+import asyncio
 import shutil
 import tempfile
+import time
 from pathlib import Path
 
+from coveo_styles.styles import echo
 from coveo_systools.filesystem import pushd
 from coveo_systools.subprocess import async_check_output
 
-from coveo_stew.ci.runner import ContinuousIntegrationRunner, RunnerStatus
+from coveo_stew.ci.runner import ContinuousIntegrationRunner
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment, PythonTool
 from coveo_stew.offline_publish import offline_publish
 
@@ -54,6 +58,10 @@ class OfflineInstallRunner(ContinuousIntegrationRunner):
                     ),
                 )
         finally:
-            shutil.rmtree(temporary_folder)
+            await asyncio.sleep(0.01)  # give a few cycles to close handles/etc
+            try:
+                shutil.rmtree(temporary_folder)
+            except PermissionError:
+                echo.warning(f"The temporary folder for this check could not be deleted: {temporary_folder}")
 
         return RunnerStatus.Success

--- a/coveo_stew/commands.py
+++ b/coveo_stew/commands.py
@@ -1,6 +1,7 @@
 """Automates poetry operations in the repo."""
 
 import re
+from collections import defaultdict
 from pathlib import Path
 from typing import Generator, Iterable, List, Set, Union
 
@@ -9,6 +10,7 @@ from coveo_functools.finalizer import finalizer
 from coveo_styles.styles import ExitWithFailure, echo, install_pretty_exception_hook
 from coveo_systools.filesystem import find_repo_root
 
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.discovery import discover_pyprojects, find_pyproject
 from coveo_stew.exceptions import (
     CheckFailed,
@@ -320,6 +322,7 @@ def refresh(project_name: str = None, exact_match: bool = False, verbose: bool =
     help="Do not call 'poetry install --remove-untracked' before testing.",
 )
 @click.option("--parallel/--sequential", default=True)
+@click.option("--github-step-report", is_flag=True, default=False, envvar="GITHUB_ACTIONS")
 def ci(
     project_name: str = None,
     exact_match: bool = False,
@@ -329,21 +332,24 @@ def ci(
     verbose: bool = False,
     quick: bool = False,
     parallel: bool = True,
+    github_step_report: bool = False
 ) -> None:
-    failures = []
+    failures = defaultdict(list)
     try:
         for project in discover_pyprojects(
             query=project_name, exact_match=exact_match, verbose=verbose
         ):
             echo.step(project.package.name, pad_after=False)
-            if not project.launch_continuous_integration(
-                auto_fix=fix, checks=check, skips=skip, quick=quick, parallel=parallel
-            ):
-                failures.append(project)
+            if (overall_result := project.launch_continuous_integration(
+                auto_fix=fix, checks=check, skips=skip, quick=quick, parallel=parallel, github=github_step_report
+            )) not in (RunnerStatus.Success, RunnerStatus.NotRan):
+                failures[overall_result].append(project)
     except PythonProjectNotFound as exception:
         raise ExitWithFailure from exception
 
+    exit_code = 2 if RunnerStatus.Error in failures else 1 if RunnerStatus.CheckFailed in failures else 0
     if failures:
-        raise ExitWithFailure(failures=failures) from CheckFailed(
+        projects = (p for projects in failures.values() for p in projects)
+        raise ExitWithFailure(failures=projects, exit_code=exit_code) from CheckFailed(
             f"{len(failures)} project(s) failed ci steps."
         )

--- a/coveo_stew/commands.py
+++ b/coveo_stew/commands.py
@@ -332,7 +332,7 @@ def ci(
     verbose: bool = False,
     quick: bool = False,
     parallel: bool = True,
-    github_step_report: bool = False
+    github_step_report: bool = False,
 ) -> None:
     failures = defaultdict(list)
     try:
@@ -340,14 +340,23 @@ def ci(
             query=project_name, exact_match=exact_match, verbose=verbose
         ):
             echo.step(project.package.name, pad_after=False)
-            if (overall_result := project.launch_continuous_integration(
-                auto_fix=fix, checks=check, skips=skip, quick=quick, parallel=parallel, github=github_step_report
-            )) not in (RunnerStatus.Success, RunnerStatus.NotRan):
+            if (
+                overall_result := project.launch_continuous_integration(
+                    auto_fix=fix,
+                    checks=check,
+                    skips=skip,
+                    quick=quick,
+                    parallel=parallel,
+                    github=github_step_report,
+                )
+            ) not in (RunnerStatus.Success, RunnerStatus.NotRan):
                 failures[overall_result].append(project)
     except PythonProjectNotFound as exception:
         raise ExitWithFailure from exception
 
-    exit_code = 2 if RunnerStatus.Error in failures else 1 if RunnerStatus.CheckFailed in failures else 0
+    exit_code = (
+        2 if RunnerStatus.Error in failures else 1 if RunnerStatus.CheckFailed in failures else 0
+    )
     if failures:
         projects = (p for projects in failures.values() for p in projects)
         raise ExitWithFailure(failures=projects, exit_code=exit_code) from CheckFailed(

--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -274,12 +274,17 @@ class PythonProject:
         skips: Optional[List[str]] = None,
         quick: bool = False,
         parallel: bool = True,
-        github: bool = False
+        github: bool = False,
     ) -> RunnerStatus:
         """Launch all continuous integration runners on the project."""
         return asyncio.run(
             self.ci.launch_continuous_integration(
-                auto_fix=auto_fix, checks=checks, skips=skips, quick=quick, parallel=parallel, github=github
+                auto_fix=auto_fix,
+                checks=checks,
+                skips=skips,
+                quick=quick,
+                parallel=parallel,
+                github=github,
             )
         )
 

--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -28,6 +28,7 @@ from coveo_itertools.lookups import dict_lookup
 from coveo_systools.filesystem import CannotFindRepoRoot, find_repo_root
 from coveo_systools.subprocess import check_run
 
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment, PythonTool, find_python_tool
 from coveo_stew.exceptions import NotAPoetryProject, StewException
 from coveo_stew.metadata.poetry_api import PoetryAPI
@@ -273,11 +274,12 @@ class PythonProject:
         skips: Optional[List[str]] = None,
         quick: bool = False,
         parallel: bool = True,
-    ) -> bool:
+        github: bool = False
+    ) -> RunnerStatus:
         """Launch all continuous integration runners on the project."""
         return asyncio.run(
             self.ci.launch_continuous_integration(
-                auto_fix=auto_fix, checks=checks, skips=skips, quick=quick, parallel=parallel
+                auto_fix=auto_fix, checks=checks, skips=skips, quick=quick, parallel=parallel, github=github
             )
         )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -96,7 +96,7 @@ typing_extensions = "*"
 
 [[package]]
 name = "coveo-systools"
-version = "2.0.9"
+version = "2.0.10"
 description = "Filesystem, language and OS related tools."
 category = "main"
 optional = false
@@ -375,7 +375,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = ">3.8.0,<4"
-content-hash = "1e08d8b6e011da1ec50ff9820283a90bba1de0194d978066e08099e4a32cbf82"
+content-hash = "34632d2c79e7166a2c7eefd6afd7b2b77515f0673699c00b100ab4ab799d620f"
 
 [metadata.files]
 atomicwrites = [
@@ -431,8 +431,8 @@ coveo-styles = [
     {file = "coveo_styles-2.1.2-py3-none-any.whl", hash = "sha256:5880def6ce0091411994eb2a25ef876f7fbf09d516c025844be84f8349f87266"},
 ]
 coveo-systools = [
-    {file = "coveo-systools-2.0.9.tar.gz", hash = "sha256:c33a741d2707bbbf723679ef14592d8263cb4b62a85db92e012d14529eb582e7"},
-    {file = "coveo_systools-2.0.9-py3-none-any.whl", hash = "sha256:5c28793bcc82d77b99986c041cfc157d5aebe9f555ea7305fe1d4186cc058649"},
+    {file = "coveo-systools-2.0.10.tar.gz", hash = "sha256:ffb9ab1d9a6909f08d38d848f784833cd7169bdb39c3fdbc41900c2b19d77660"},
+    {file = "coveo_systools-2.0.10-py3-none-any.whl", hash = "sha256:fe706743a48f8ba6da9e2efe2a717bc60d4974478c1271c61bf59f76a2e93a01"},
 ]
 coveo-testing = [
     {file = "coveo-testing-2.0.7.tar.gz", hash = "sha256:b47250f62ac60baebc535c5fe579aa1c45371d8b383b71ff9026c5c38989fa96"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ python = ">3.8.0,<4"
 click = ">=8.1"
 coveo-functools = "^2.0.0"
 coveo-itertools = "^2.0.0"
-coveo-systools = "^2.0.9"
+coveo-systools = "^2.0.10"
 coveo-styles = "^2.1.2"
 junit-xml = "*"
 toml = "*"
@@ -48,7 +48,7 @@ black = true
 
 
 [tool.stew.ci.custom-runners]
-flake8 = { check-args = "--ignore=E501,W503" }
+flake8 = { check-args = "--zignore=E501,W503" }
 
 [tool.stew.ci.custom-runners.isort]
 check-args = ["--check", "--profile", "black", "."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ black = true
 
 
 [tool.stew.ci.custom-runners]
-flake8 = { check-args = "--zignore=E501,W503" }
+flake8 = { check-args = "--ignore=E501,W503" }
 
 [tool.stew.ci.custom-runners.isort]
 check-args = ["--check", "--profile", "black", "."]

--- a/test_coveo_stew/test_stew_ci.py
+++ b/test_coveo_stew/test_stew_ci.py
@@ -7,6 +7,7 @@ from _pytest.tmpdir import TempPathFactory
 from coveo_testing.parametrize import parametrize
 
 from coveo_stew.ci.runner import ContinuousIntegrationRunner
+from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.stew import PythonProject
 
 PROJECT_NAME: Final = "mock_linter_errors"
@@ -313,8 +314,8 @@ def write_code(project: PythonProject, code: str) -> Generator[None, None, None]
 @parametrize(
     ("code", "expected_outcome"),
     (
-        (BROKEN_CODE, False),
-        (WORKING_CODE, True),
+        (BROKEN_CODE, RunnerStatus.CheckFailed),
+        (WORKING_CODE, RunnerStatus.Success),
     ),
     ids=("broken", "correct"),
 )
@@ -328,21 +329,22 @@ def write_code(project: PythonProject, code: str) -> Generator[None, None, None]
     ids=("mypy", "isort", "black"),
 )
 def test_linters(
-    code: str, expected_outcome: bool, check: str, failure_text: str, linter_project: PythonProject
+    code: str, expected_outcome: RunnerStatus, check: str, failure_text: str, linter_project: PythonProject
 ) -> None:
     with write_code(linter_project, code):
         outcome = linter_project.launch_continuous_integration(checks=[check], quick=True)
+        assert outcome in (RunnerStatus.Success, RunnerStatus.CheckFailed)
         ci_runner = _check_result(outcome, expected_outcome, linter_project, check, failure_text)
-        if expected_outcome is False and ci_runner.supports_auto_fix:
+        if expected_outcome is RunnerStatus.CheckFailed and ci_runner.supports_auto_fix:
             outcome = linter_project.launch_continuous_integration(
                 auto_fix=True, checks=[check], quick=True
             )
-            _ = _check_result(outcome, not expected_outcome, linter_project, check, failure_text)
+            _ = _check_result(outcome, RunnerStatus.Success, linter_project, check, failure_text)
 
 
 def _check_result(
-    outcome: bool,
-    expected_outcome: bool,
+    outcome: RunnerStatus,
+    expected_outcome: RunnerStatus,
     project: PythonProject,
     check_name: str,
     failure_text: str,
@@ -350,7 +352,7 @@ def _check_result(
     assert outcome is expected_outcome
     check_instance = project.ci.get_runner(check_name)
     assert isinstance(check_instance, ContinuousIntegrationRunner)
-    if expected_outcome:
+    if expected_outcome is RunnerStatus.Success:
         assert failure_text not in check_instance.last_output()
     else:
         assert failure_text in check_instance.last_output()

--- a/test_coveo_stew/test_stew_ci.py
+++ b/test_coveo_stew/test_stew_ci.py
@@ -329,7 +329,11 @@ def write_code(project: PythonProject, code: str) -> Generator[None, None, None]
     ids=("mypy", "isort", "black"),
 )
 def test_linters(
-    code: str, expected_outcome: RunnerStatus, check: str, failure_text: str, linter_project: PythonProject
+    code: str,
+    expected_outcome: RunnerStatus,
+    check: str,
+    failure_text: str,
+    linter_project: PythonProject,
 ) -> None:
     with write_code(linter_project, code):
         outcome = linter_project.launch_continuous_integration(checks=[check], quick=True)


### PR DESCRIPTION
This initially started as a simple step report for github, but testing uncovered some little details around error management that I also fixed in this PR.

- Adds a github step report when ran from github actions
- Stew will now exit 2 on error, 1 on check failure
- CLI feedback improved (shorter, less repetitions, cleaner colors)
- Don't fail fast anymore; collect the failures and output everything
- Fix/bypass an occasional permission error when clearing the temp folder


e.g.: summary with failures and errors https://github.com/coveo/stew/actions/runs/2926852827#summary-8016813573

![image](https://user-images.githubusercontent.com/5009356/186676680-a063a2c9-3549-43c8-8c13-ff73811714bb.png)

