### PR TITLE
Allow skipping python install and specifying the python executable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,19 +12,29 @@ inputs:
     required: true
 
   poetry-version:
-    default: "<1.2.0"
-    required: false
     description: The pip constraint when installing poetry.
+    required: false
+    default: "<1.2.0"
 
   coveo-stew-version:
-    default: "<4"
     description: The pip constraint when installing coveo-stew.
     required: false
+    default: "<4"
 
   run-stew:
     description: If not "true", `stew ci` will not be ran. This is a shortcut to checkout/setup-python/poetry/stew without running it.
     required: false
     default: "true"
+
+  install-python:
+    description: Can be set to false to skip installing python.
+    required: false
+    default: "true"
+
+  python-exec:
+    description: The name of the python executable
+    required: false
+    default: "python"
 
 
 runs:
@@ -33,6 +43,7 @@ runs:
   steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      if: inputs.install-python == 'true'
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -42,16 +53,20 @@ runs:
 
     - name: Upgrade python tools and install pipx
       shell: bash
-      run: python -m pip install --upgrade pip wheel setuptools pipx --user --disable-pip-version-check
+      env:
+        PYTHON_EXEC: ${{ inputs.python-exec }}
+      run: $PYTHON_EXEC -m pip install --upgrade pip wheel setuptools pipx --user --disable-pip-version-check
 
     - name: poetry and stew
       shell: bash
       env:
         POETRY_VERSION: ${{ inputs.poetry-version }}
         COVEO_STEW_VERSION: ${{ inputs.coveo-stew-version }}
+        PYTHON_EXEC: ${{ inputs.python-exec }}
+
       run: | 
-        python -m pipx install "poetry$POETRY_VERSION"
-        python -m pipx install "coveo-stew$COVEO_STEW_VERSION"
+        $PYTHON_EXEC -m pipx install "poetry$POETRY_VERSION"
+        $PYTHON_EXEC -m pipx install "coveo-stew$COVEO_STEW_VERSION"
 
     - name: Run stew ci
       if: inputs.run-stew == 'true'


### PR DESCRIPTION
`actions/setup-python` does not support arm64, so you can't use it on arm64 self-hosted runners.

These options provide an escape hatch to allow user-defined python setups.