### PR TITLE
Keep the directory as absolute

### DIFF
--- a/coveo_stew/commands.py
+++ b/coveo_stew/commands.py
@@ -176,7 +176,7 @@ def build(
     if not directory:
         directory = (project.repo_root or project.project_path) / ".wheels"
     assert directory
-    directory = Path(directory)
+    directory = Path(directory).absolute()
 
     echo.step(f"Building python project {project} in {directory}")
     for environment in python_environments:


### PR DESCRIPTION
Fix a bug when `--directory` is given as a relative folder.

The problematic code is [here](https://github.com/coveo/stew/blob/ef95690d24a8b0a0c0aebdfaba5b8fe9e8e7e720/coveo_stew/offline_publish.py#L161). When `self.wheelhouse` is a relative directory, the command will fail.