### PR TITLE
fix: "extras" and "all-extras" not applied for environments created by stew

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ quick = {}
 - **pydev**: See the [multiple-libraries](README_MULTIPLE_LIBRARIES.md) guide.
 - **build-dependencies**: You can specify additional dependencies to be installed during `stew build`.
   - The format is the same as poetry dependencies: `name = "version"` or `name = { version = "version", ... }`
-- **extras**: A list of extras to install during `stew build` (and `stew ci`: added in *v3.0.33*).
-- **all-extras**: If true, all extras will be installed during `stew build` (and `stew ci`: added in *v3.0.33*). Overrides the `extras` list.
+- **extras**: A list of extras to install during `stew build` and `stew ci`.
+- **all-extras**: If true, all extras will be installed during `stew build` and `stew ci`. Overrides the `extras` list.
 - **quick**: *(v3.0.30)* Controls which checks are skipped when calling `stew ci --quick`. 
   - The format is a dictionary with either the `check` or `skip` key, followed by a list of runners.
   - The behavior is identical to the `--check` and `--skip` options.

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ quick = {}
 - **pydev**: See the [multiple-libraries](README_MULTIPLE_LIBRARIES.md) guide.
 - **build-dependencies**: You can specify additional dependencies to be installed during `stew build`.
   - The format is the same as poetry dependencies: `name = "version"` or `name = { version = "version", ... }`
-- **extras**: A list of extras to install during `stew build`. 
-- **all-extras**: If true, all extras will be installed during `stew build`. Overrides the `extras` list.
+- **extras**: A list of extras to install during `stew build` (and `stew ci`: added in *v3.0.33*).
+- **all-extras**: If true, all extras will be installed during `stew build` (and `stew ci`: added in *v3.0.33*). Overrides the `extras` list.
 - **quick**: *(v3.0.30)* Controls which checks are skipped when calling `stew ci --quick`. 
   - The format is a dictionary with either the `check` or `skip` key, followed by a list of runners.
   - The behavior is identical to the `--check` and `--skip` options.

--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -341,7 +341,9 @@ class PythonProject:
         target_environment.installed = True
         target_environment.cleaned |= sync
 
-    def _generate_poetry_install_command(self, sync_target_environment: Optional[PythonEnvironment] = None, quiet: bool = False) -> List[str]:
+    def _generate_poetry_install_command(
+        self, sync_target_environment: Optional[PythonEnvironment] = None, quiet: bool = False
+    ) -> List[str]:
         command: List[str] = ["install"]
         if sync_target_environment:
             command.append(get_verb("--sync", sync_target_environment))

--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -187,15 +187,18 @@ class PythonProject:
     ) -> PythonEnvironment:
         """To be used only when no environments exist. Creates a default one by calling "poetry install"."""
         if install is EnvironmentCreationBehavior.Full:
-            self.poetry_run("install")
+            command = self._generate_poetry_install_command()
         elif install is EnvironmentCreationBehavior.NoDev:
-            self.poetry_run("install", "--no-dev")
+            command = self._generate_poetry_install_command()
+            command.append("--no-dev")
         else:
             assert install is EnvironmentCreationBehavior.Empty
             try:
-                self.poetry_run("env", "use", "python3")
+                command = ["env", "use", "python3"]
             except CalledProcessError:
-                self.poetry_run("env", "use", "python")
+                command = ["env", "use", "python"]
+
+        self.poetry_run(*command)
 
         del self._virtual_environments_cache  # force cache refresh
         activated_environment = self.activated_environment()
@@ -333,9 +336,15 @@ class PythonProject:
                 # return unless we are cleaning a non-cleaned environment
                 return
 
+        command = self._generate_poetry_install_command(target_environment if sync else None, quiet)
+        self.poetry_run(*command, environment=target_environment)
+        target_environment.installed = True
+        target_environment.cleaned |= sync
+
+    def _generate_poetry_install_command(self, sync_target_environment: Optional[PythonEnvironment] = None, quiet: bool = False) -> List[str]:
         command: List[str] = ["install"]
-        if sync:
-            command.append(get_verb("--sync", target_environment))
+        if sync_target_environment:
+            command.append(get_verb("--sync", sync_target_environment))
         if quiet and not self.verbose:
             command.append("--quiet")
         if self.options.all_extras:
@@ -343,10 +352,7 @@ class PythonProject:
         elif self.options.extras:
             for extra in self.options.extras:
                 command.extend(["--extras", extra])
-
-        self.poetry_run(*command, environment=target_environment)
-        target_environment.installed = True
-        target_environment.cleaned |= sync
+        return command
 
     def remove_egg_info(self) -> bool:
         """Removes the egg-info (editable project hook) from the folder. Returns True if we removed it."""


### PR DESCRIPTION
When calling `stew ci` on a project without a virtual environment setup, we use `poetry install` to delegate the work to poetry. We don't use the `self.install()` method because it would create an infinite loop (the install method requires an environment). This causes the behaviors around `extras` to be lost since it was in the `install()` method.

I extracted the command creation logic and reused it in both code paths.