### PR TITLE
fix(build): ensure poetry export returns index credentials

### DIFF
--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -307,7 +307,7 @@ class PythonProject:
 
     def export(self) -> str:
         """Generates the content of a `requirements.txt` file based on the lock."""
-        command = ["export"]
+        command = ["export", "--with-credentials"]
         if self.options.build_without_hashes:
             command.append("--without-hashes")
 


### PR DESCRIPTION
This PR fixes an issue when using `stew build` with a private password protected registry. When `stew` downloads the wheels for all dependencies, it does so by calling `poetry export` followed by `pip` wheels.

If you happen to have a primary source configured in your `pyproject.toml` and that this primary source is password protected, you'll get an error about pip being unable to resolve any package in your project.

This happens because by default `poetry export` adds an `--index-url` in its output but the URL it produces doesn't include credentials. This PR changes the way `poetry export` is called so that the `--index-url` now includes any credentials if they're preset.