### PR TITLE
fix(ci): fix some vulnerabilities def-3916

### DIFF
--- a/.github/workflows/coveo-stew.yml
+++ b/.github/workflows/coveo-stew.yml
@@ -15,6 +15,8 @@ on:
         required: false
         default: 'false'
 
+permissions:
+  contents: read
 
 jobs:
   compatibility:
@@ -29,7 +31,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
 
@@ -71,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           egress-policy: audit
 


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/coveo-stew.yml` file to enhance security and specify permissions.

Security enhancements:

* Updated the `step-security/harden-runner` action to use a specific commit hash for version `v2.10.4` in two job steps to ensure consistency and security. [[1]](diffhunk://#diff-af92e9094c4df007887e25d184ff328e601a032e95a40deb9fa8491a2fb3c155L32-R34) [[2]](diffhunk://#diff-af92e9094c4df007887e25d184ff328e601a032e95a40deb9fa8491a2fb3c155L74-R76)

Permissions specification:

* Added `permissions` section to explicitly set `contents: read` for the workflow.