### PR TITLE
Add support for '[project]' in pyproject.toml

### DIFF
--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -66,10 +66,12 @@ class PythonProject:
 
         toml_content = load_toml_from_path(self.toml_path)
 
+        mandatory_poetry_fields = ["name", "version", "description", "authors"]
+        project_section = dict_lookup(toml_content, "project")
+        if any([ project_section.get(x) is None for x in mandatory_poetry_fields]):
+            project_section = dict_lookup(toml_content, "tool", "poetry")  # poetry < 2
         try:
-            self.package: PoetryAPI = flexfactory(
-                PoetryAPI, **dict_lookup(toml_content, "tool", "poetry")
-            )
+            self.package: PoetryAPI = flexfactory(PoetryAPI, **project_section)
         except KeyError as exception:
             raise NotAPoetryProject from exception
 

--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -66,12 +66,10 @@ class PythonProject:
 
         toml_content = load_toml_from_path(self.toml_path)
 
-        mandatory_poetry_fields = ["name", "version", "description", "authors"]
-        project_section = dict_lookup(toml_content, "project")
-        if any([ project_section.get(x) is None for x in mandatory_poetry_fields]):
-            project_section = dict_lookup(toml_content, "tool", "poetry")  # poetry < 2
         try:
-            self.package: PoetryAPI = flexfactory(PoetryAPI, **project_section)
+            tool_poetry_section = dict_lookup(toml_content, "tool", "poetry")
+            tool_poetry_section.update(toml_content.get("project", {}))
+            self.package: PoetryAPI = flexfactory(PoetryAPI, **tool_poetry_section)
         except KeyError as exception:
             raise NotAPoetryProject from exception
 

--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -67,10 +67,10 @@ class PythonProject:
         toml_content = load_toml_from_path(self.toml_path)
 
         try:
-            tool_poetry_section = dict_lookup(toml_content, "tool", "poetry")
+            tool_poetry_section = dict_lookup(toml_content, "tool", "poetry", default={})
             tool_poetry_section.update(toml_content.get("project", {}))
             self.package: PoetryAPI = flexfactory(PoetryAPI, **tool_poetry_section)
-        except KeyError as exception:
+        except TypeError as exception:
             raise NotAPoetryProject from exception
 
         self.egg_path: Path = self.project_path / f"{self.package.safe_name}.egg-info"

--- a/test_coveo_stew/pyprojet_mock/mock-poetry-groups/mock.pyproject.toml
+++ b/test_coveo_stew/pyprojet_mock/mock-poetry-groups/mock.pyproject.toml
@@ -1,4 +1,4 @@
-[tool.poetry]
+[project]
 name = "mock-poetry-groups"
 version = "0.1.1"
 description = "an internal mock for stew's tests"

--- a/test_coveo_stew/pyprojet_mock/mock-pyproject/mock.pyproject.toml
+++ b/test_coveo_stew/pyprojet_mock/mock-pyproject/mock.pyproject.toml
@@ -1,4 +1,4 @@
-[tool.poetry]
+[project]
 name = "mock-pyproject"
 version = "0.1.1"
 description = "an internal mock for stew's tests"

--- a/test_coveo_stew/pyprojet_mock/mock-pyproject/mock.pyproject.toml
+++ b/test_coveo_stew/pyprojet_mock/mock-pyproject/mock.pyproject.toml
@@ -1,4 +1,4 @@
-[project]
+[tool.poetry]
 name = "mock-pyproject"
 version = "0.1.1"
 description = "an internal mock for stew's tests"


### PR DESCRIPTION
I got the error `TypeError: PoetryAPI.__init__() missing 4 required keyword-only arguments: 'name', 'version', 'description', and 'authors'` with `stew`. After digging, I realized that it was because it was reading a `pyproject.toml` file that has a `[project]` section. This is the new standard, supported by poetry since version 2. This is explained on [packaging.python.org/en/latest/guides/writing-pyproject-tom](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/)

> A notable exception is [Poetry](https://python-poetry.org/), which before version 2.0 (released January 5, 2025) did not use the [project] table, it used the [tool.poetry] table instead. With version 2.0, it supports both.

And then a few lines later

> For new projects, use the [project] table

Hence, I added the support for the `[project]` tab.

I modified the mock-group project to test. `test_coveo_stew/pyprojet_mock/mock-pyproject/mock.pyproject.toml` still uses `tool.poetry`.