### PR TITLE
fix: skip over pyproject files that can't be loaded

### DIFF
--- a/.github/workflows/coveo-stew.yml
+++ b/.github/workflows/coveo-stew.yml
@@ -49,6 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: compatibility
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/coveo_stew/discovery.py
+++ b/coveo_stew/discovery.py
@@ -60,7 +60,9 @@ def discover_pyprojects(
     for file in paths:
         try:
             project = PythonProject(file, verbose=verbose)
-        except NotAPoetryProject:
+        except NotAPoetryProject as ex:
+            # this will inform the user which pyproject.toml files were found and skipped
+            echo.noise(ex, " It was skipped.", emoji="information")
             continue
 
         if verbose:

--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -66,8 +66,10 @@ class PythonProject:
             self.package: PoetryAPI = flexfactory(
                 PoetryAPI, **dict_lookup(toml_content, "tool", "poetry")
             )
-        except KeyError as exception:
-            raise NotAPoetryProject from exception
+        except (KeyError, TypeError) as exception:
+            raise NotAPoetryProject(
+                f"The pyproject.toml file at {self.toml_path} doesn't seem to include a poetry project."
+            ) from exception
 
         self.egg_path: Path = self.project_path / f"{self.package.safe_name}.egg-info"
 


### PR DESCRIPTION
In poetry `1.8.0` they added a `package-mode = false` feature. This feature allows using poetry without a project name/description/author, which was required in the past. Stew's discovery will fail with a `TypeError` in this case, since the constructor arguments are wrong but a `[tool.poetry]` section was present.

I will of course add support for the package-mode=false at some point, but meanwhile, let's skip these projects and warn the user.

Tested manually:

![image](https://github.com/user-attachments/assets/2fece02d-5bdf-4f24-ac5a-e0945670eacf)
