### PR TITLE
feat(ci): add --color/--no-color flag to stew ci

### DIFF
--- a/coveo_stew/ci/config.py
+++ b/coveo_stew/ci/config.py
@@ -107,6 +107,7 @@ class ContinuousIntegrationConfig:
         checks: Optional[Iterable[str]],
         skips: Optional[Iterable[str]],
         parallel: bool = True,
+        color: Optional[bool] = None,
     ) -> Generator[CIPlan, None, None]:
         """Generates one test plan per environment."""
         checks = [check.lower() for check in checks] if checks else []
@@ -122,7 +123,7 @@ class ContinuousIntegrationConfig:
                     continue
                 runners.append(runner)
 
-            yield CIPlan(environment, runners, parallel)
+            yield CIPlan(environment, runners, parallel, color=color)
 
     async def launch_continuous_integration(
         self,
@@ -133,11 +134,12 @@ class ContinuousIntegrationConfig:
         parallel: bool,
         github: bool,
         show_success_output: bool,
+        color: Optional[bool] = None,
     ) -> RunnerStatus:
         if self.disabled:
             return RunnerStatus.NotRan
 
-        ci_plans = list(self._generate_ci_plans(checks=checks, skips=skips, parallel=parallel))
+        ci_plans = list(self._generate_ci_plans(checks=checks, skips=skips, parallel=parallel, color=color))
         for plan in ci_plans:
             if not quick:
                 self._pyproject.install(environment=plan.environment, sync=True)

--- a/coveo_stew/ci/config.py
+++ b/coveo_stew/ci/config.py
@@ -139,7 +139,9 @@ class ContinuousIntegrationConfig:
         if self.disabled:
             return RunnerStatus.NotRan
 
-        ci_plans = list(self._generate_ci_plans(checks=checks, skips=skips, parallel=parallel, color=color))
+        ci_plans = list(
+            self._generate_ci_plans(checks=checks, skips=skips, parallel=parallel, color=color)
+        )
         for plan in ci_plans:
             if not quick:
                 self._pyproject.install(environment=plan.environment, sync=True)

--- a/coveo_stew/ci/mypy_runner.py
+++ b/coveo_stew/ci/mypy_runner.py
@@ -13,9 +13,9 @@ from coveo_systools.subprocess import async_check_output
 from coveo_stew.ci.runner import ContinuousIntegrationRunner
 from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment, PythonTool
-from coveo_stew.utils import strip_ansi
 from coveo_stew.metadata.python_api import PythonFile
 from coveo_stew.stew import PythonProject
+from coveo_stew.utils import strip_ansi
 
 
 class MypyRunner(ContinuousIntegrationRunner):

--- a/coveo_stew/ci/mypy_runner.py
+++ b/coveo_stew/ci/mypy_runner.py
@@ -13,6 +13,7 @@ from coveo_systools.subprocess import async_check_output
 from coveo_stew.ci.runner import ContinuousIntegrationRunner
 from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.environment import PythonEnvironment, PythonTool
+from coveo_stew.utils import strip_ansi
 from coveo_stew.metadata.python_api import PythonFile
 from coveo_stew.stew import PythonProject
 
@@ -230,7 +231,8 @@ class MypyRunner(ContinuousIntegrationRunner):
         )
 
         for line in self._last_output:
-            match = pattern.fullmatch(line)
+            clean_line = strip_ansi(line)
+            match = pattern.fullmatch(clean_line)
             if match:
                 adjusted_path = (self._pyproject.project_path / Path(match["path"])).resolve()
                 echo.error_details(
@@ -238,3 +240,4 @@ class MypyRunner(ContinuousIntegrationRunner):
                 )
             else:
                 echo.noise(line)
+

--- a/coveo_stew/ci/mypy_runner.py
+++ b/coveo_stew/ci/mypy_runner.py
@@ -240,4 +240,3 @@ class MypyRunner(ContinuousIntegrationRunner):
                 )
             else:
                 echo.noise(line)
-

--- a/coveo_stew/ci/pytest_runner.py
+++ b/coveo_stew/ci/pytest_runner.py
@@ -29,9 +29,11 @@ class PytestRunner(ContinuousIntegrationRunner):
     async def _launch(
         self, environment: PythonEnvironment, *extra_args: str, **kwargs: Any
     ) -> RunnerStatus:
+        env = kwargs.get("env", {})
+        pytest_color = "no" if env.get("NO_COLOR") == "1" else "yes"
         command = environment.build_command(
             PythonTool.Pytest,
-            "--color=yes",
+            f"--color={pytest_color}",
             "--durations=5",
             "--tb=short",
             f"--junitxml={self.report_path(environment)}",

--- a/coveo_stew/ci/runner.py
+++ b/coveo_stew/ci/runner.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
 from typing import Any, Coroutine, Iterable, List, Optional, Protocol, Sequence, Tuple
@@ -52,6 +52,7 @@ class ContinuousIntegrationRunner:
         environment: PythonEnvironment = None,
         *extra_args: str,
         auto_fix: bool = False,
+        color: Optional[bool] = None,
     ) -> "ContinuousIntegrationRunner":
         """
         Launch the runner's checks.
@@ -63,6 +64,25 @@ class ContinuousIntegrationRunner:
 
         # without this, some tools like black will not display emojis correctly
         environment_variables["PYTHONIOENCODING"] = "utf-8"
+
+        # resolve color: explicit True/False wins; None falls back to TTY + env detection
+        wants_color = color if color is not None else bool(
+            os.isatty(1)
+            or os.environ.get("FORCE_COLOR")
+            or os.environ.get("PY_COLORS")
+            or os.environ.get("CLICOLOR_FORCE")
+        )
+        if wants_color:
+            environment_variables["FORCE_COLOR"] = "1"
+            environment_variables["PY_COLORS"] = "1"
+            environment_variables["CLICOLOR_FORCE"] = "1"
+            environment_variables["MYPY_FORCE_COLOR"] = "1"
+            environment_variables.pop("NO_COLOR", None)
+        else:
+            environment_variables["NO_COLOR"] = "1"
+            environment_variables["FORCE_COLOR"] = "0"
+            environment_variables["PY_COLORS"] = "0"
+            environment_variables.pop("CLICOLOR_FORCE", None)
 
         # try to set the terminal width if available
         if os.isatty(0):
@@ -88,7 +108,7 @@ class ContinuousIntegrationRunner:
             await self._auto_fix_routine(environment, env=environment_variables)
 
             # it should pass now!
-            await self.launch(environment, *extra_args)
+            await self.launch(environment, *extra_args, color=color)
             if self.status == RunnerStatus.CheckFailed:
                 echo.error("The auto fix routine was launched but the check is still failing.")
             else:
@@ -180,6 +200,7 @@ class CIPlan:
     environment: PythonEnvironment
     checks: Sequence[ContinuousIntegrationRunner]
     parallel: bool
+    color: Optional[bool] = field(default=None)
 
     @cached_property
     def autofix_checks(self) -> List[ContinuousIntegrationRunner]:
@@ -202,7 +223,7 @@ class CIPlan:
 
         if auto_fix:
             # run autofix first, in parallel
-            runs.append(run := Run(self.environment, self.autofix_checks))
+            runs.append(run := Run(self.environment, self.autofix_checks, color=self.color))
             await run.run_and_report(
                 parallel=self.parallel, show_success_output=show_success_output
             )
@@ -214,13 +235,13 @@ class CIPlan:
                 )  # verify that autofix worked
 
             # run all other runners
-            runs.append(run := Run(self.environment, self.non_autofix_checks))
+            runs.append(run := Run(self.environment, self.non_autofix_checks, color=self.color))
             await run.run_and_report(
                 parallel=self.parallel, show_success_output=show_success_output
             )
 
         else:
-            runs.append(run := Run(self.environment, self.checks))
+            runs.append(run := Run(self.environment, self.checks, color=self.color))
             await run.run_and_report(
                 parallel=self.parallel, show_success_output=show_success_output
             )
@@ -245,6 +266,7 @@ class Run:
 
     environment: PythonEnvironment
     checks: Sequence[ContinuousIntegrationRunner]
+    color: Optional[bool] = field(default=None)
 
     @cached_property
     def exceptions(
@@ -274,7 +296,7 @@ class Run:
 
         if parallel:
             for next_result in asyncio.as_completed(
-                [runner.launch(self.environment, auto_fix=False) for runner in self.checks]
+                [runner.launch(self.environment, auto_fix=False, color=self.color) for runner in self.checks]
             ):
                 try:
                     result = await next_result
@@ -287,7 +309,7 @@ class Run:
         else:
             for runner in self.checks:
                 self._report(
-                    await runner.launch(self.environment, auto_fix=auto_fix),
+                    await runner.launch(self.environment, auto_fix=auto_fix, color=self.color),
                     feedback=feedback,
                 )
 

--- a/coveo_stew/ci/runner.py
+++ b/coveo_stew/ci/runner.py
@@ -66,11 +66,15 @@ class ContinuousIntegrationRunner:
         environment_variables["PYTHONIOENCODING"] = "utf-8"
 
         # resolve color: explicit True/False wins; None falls back to TTY + env detection
-        wants_color = color if color is not None else bool(
-            os.isatty(1)
-            or os.environ.get("FORCE_COLOR")
-            or os.environ.get("PY_COLORS")
-            or os.environ.get("CLICOLOR_FORCE")
+        wants_color = (
+            color
+            if color is not None
+            else bool(
+                os.isatty(1)
+                or os.environ.get("FORCE_COLOR")
+                or os.environ.get("PY_COLORS")
+                or os.environ.get("CLICOLOR_FORCE")
+            )
         )
         if wants_color:
             environment_variables["FORCE_COLOR"] = "1"
@@ -296,7 +300,10 @@ class Run:
 
         if parallel:
             for next_result in asyncio.as_completed(
-                [runner.launch(self.environment, auto_fix=False, color=self.color) for runner in self.checks]
+                [
+                    runner.launch(self.environment, auto_fix=False, color=self.color)
+                    for runner in self.checks
+                ]
             ):
                 try:
                     result = await next_result

--- a/coveo_stew/commands.py
+++ b/coveo_stew/commands.py
@@ -5,8 +5,8 @@ from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import Generator, Optional, Set, Tuple, Union
 
-from cleo.io.io import IO
 import click
+from cleo.io.io import IO
 from coveo_functools.finalizer import finalizer
 from coveo_styles.styles import ExitWithFailure, echo
 from coveo_systools.filesystem import find_repo_root

--- a/coveo_stew/commands.py
+++ b/coveo_stew/commands.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Generator, Optional, Set, Tuple, Union
 
 from cleo.io.io import IO
+import click
 from coveo_functools.finalizer import finalizer
 from coveo_styles.styles import ExitWithFailure, echo
 from coveo_systools.filesystem import find_repo_root
@@ -372,8 +373,13 @@ def ci(
     all_extras: bool = False,
     disable_cache: bool = False,
     show_success_output: bool = False,
+    color: Optional[bool] = None,
 ) -> None:
     """Run continuous integration steps on Python projects."""
+    ctx = click.get_current_context(silent=True)
+    if ctx is not None and color is not None:
+        ctx.color = color
+
     failures = defaultdict(list)
     try:
         for project in _discover_pyprojects(
@@ -400,6 +406,7 @@ def ci(
                     parallel=parallel,
                     github=github_step_report,
                     show_success_output=show_success_output,
+                    color=color,
                 )
             ) not in (RunnerStatus.Success, RunnerStatus.NotRan):
                 failures[overall_result].append(project)

--- a/coveo_stew/stew.py
+++ b/coveo_stew/stew.py
@@ -350,6 +350,7 @@ class PythonProject:
         parallel: bool = True,
         github: bool = False,
         show_success_output: bool = False,
+        color: Optional[bool] = None,
     ) -> RunnerStatus:
         """Launch all continuous integration runners on the project."""
         return asyncio.run(
@@ -361,6 +362,7 @@ class PythonProject:
                 parallel=parallel,
                 github=github,
                 show_success_output=show_success_output,
+                color=color,
             )
         )
 

--- a/coveo_stew/ui/click/cli.py
+++ b/coveo_stew/ui/click/cli.py
@@ -285,6 +285,7 @@ def refresh(
 )
 @click.option("--no-extras", is_flag=True, help="Don't use any extras when testing.")
 @click.option("--all-extras", is_flag=True, help="Use all extras when testing.")
+@click.option("--color/--no-color", default=None, help="Force enable or disable terminal color.")
 @NO_CACHE_ARG
 def ci(
     project_name: str = None,
@@ -302,6 +303,7 @@ def ci(
     all_extras: bool = False,
     no_cache: bool = False,
     show_success_output: bool = False,
+    color: Optional[bool] = None,
 ) -> None:
     """Run continuous integration steps on Python projects."""
 
@@ -330,6 +332,7 @@ def ci(
         all_extras=all_extras,
         disable_cache=no_cache,
         show_success_output=show_success_output,
+        color=color,
     )
 
 

--- a/coveo_stew/utils.py
+++ b/coveo_stew/utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 from typing import Any, MutableMapping
 
 import toml
@@ -17,3 +18,13 @@ def _load_toml_from_content(toml_content: str, toml_path: Path) -> MutableMappin
     except TomlDecodeError as ex:
         lineno, colno = ex.lineno, ex.colno
         raise ExitWithFailure(suggestions=f"{toml_path}:{lineno}:{colno} parse error") from ex
+
+
+_ANSI_ESCAPE = re.compile(r'\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\([A-Z0-9])')
+
+
+def strip_ansi(text: str) -> str:
+    """Strips ANSI and VT100 character set escape sequences from a string."""
+    return _ANSI_ESCAPE.sub('', text)
+
+

--- a/coveo_stew/utils.py
+++ b/coveo_stew/utils.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import re
+from pathlib import Path
 from typing import Any, MutableMapping
 
 import toml

--- a/coveo_stew/utils.py
+++ b/coveo_stew/utils.py
@@ -20,11 +20,9 @@ def _load_toml_from_content(toml_content: str, toml_path: Path) -> MutableMappin
         raise ExitWithFailure(suggestions=f"{toml_path}:{lineno}:{colno} parse error") from ex
 
 
-_ANSI_ESCAPE = re.compile(r'\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\([A-Z0-9])')
+_ANSI_ESCAPE = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\([A-Z0-9])")
 
 
 def strip_ansi(text: str) -> str:
     """Strips ANSI and VT100 character set escape sequences from a string."""
-    return _ANSI_ESCAPE.sub('', text)
-
-
+    return _ANSI_ESCAPE.sub("", text)

--- a/test_coveo_stew/test_stew_ci.py
+++ b/test_coveo_stew/test_stew_ci.py
@@ -419,12 +419,11 @@ def _check_result(
     assert outcome is expected_outcome
     check_instance = project.ci.get_runner(check_name)
     assert isinstance(check_instance, ContinuousIntegrationRunner)
-    
+
     last_output = strip_ansi(check_instance.last_output())
-    
+
     if expected_outcome is RunnerStatus.Success:
         assert failure_text not in last_output
     else:
         assert failure_text in last_output
     return check_instance
-

--- a/test_coveo_stew/test_stew_ci.py
+++ b/test_coveo_stew/test_stew_ci.py
@@ -9,6 +9,7 @@ from coveo_testing.parametrize import parametrize
 from coveo_stew.ci.runner import ContinuousIntegrationRunner
 from coveo_stew.ci.runner_status import RunnerStatus
 from coveo_stew.stew import PythonProject
+from coveo_stew.utils import strip_ansi
 
 PROJECT_NAME: Final = "mock_linter_errors"
 
@@ -418,8 +419,12 @@ def _check_result(
     assert outcome is expected_outcome
     check_instance = project.ci.get_runner(check_name)
     assert isinstance(check_instance, ContinuousIntegrationRunner)
+    
+    last_output = strip_ansi(check_instance.last_output())
+    
     if expected_outcome is RunnerStatus.Success:
-        assert failure_text not in check_instance.last_output()
+        assert failure_text not in last_output
     else:
-        assert failure_text in check_instance.last_output()
+        assert failure_text in last_output
     return check_instance
+

--- a/test_coveo_stew/test_utils.py
+++ b/test_coveo_stew/test_utils.py
@@ -1,0 +1,20 @@
+import pytest
+from coveo_testing.parametrize import parametrize
+
+from coveo_stew.utils import strip_ansi
+
+
+@parametrize(
+    "text, expected",
+    (
+        ("plain text", "plain text"),
+        ("", ""),
+        ("\x1b[31mred\x1b[0m", "red"),
+        ("\x1b[1;32mbold green\x1b[0m", "bold green"),
+        ("\x1b[0m", ""),
+        ("before \x1b[33myellow\x1b[0m after", "before yellow after"),
+        ("\x1b(Bsome text", "some text"),  # VT100 character set sequence
+    ),
+)
+def test_strip_ansi(text: str, expected: str) -> None:
+    assert strip_ansi(text) == expected

--- a/test_coveo_stew/test_utils.py
+++ b/test_coveo_stew/test_utils.py
@@ -1,4 +1,3 @@
-import pytest
 from coveo_testing.parametrize import parametrize
 
 from coveo_stew.utils import strip_ansi

--- a/test_coveo_stew/test_validate_toml.py
+++ b/test_coveo_stew/test_validate_toml.py
@@ -47,3 +47,4 @@ def test_toml_repeated_section() -> None:
     assert isinstance(exception.__cause__, TomlDecodeError)
     assert f"{DUMMY_TEST_PATH}:{error_line}:{error_col}" in str(exception)
     assert "already exists" in str(exception)  # may change with new toml parser versions
+

--- a/test_coveo_stew/test_validate_toml.py
+++ b/test_coveo_stew/test_validate_toml.py
@@ -47,4 +47,3 @@ def test_toml_repeated_section() -> None:
     assert isinstance(exception.__cause__, TomlDecodeError)
     assert f"{DUMMY_TEST_PATH}:{error_line}:{error_col}" in str(exception)
     assert "already exists" in str(exception)  # may change with new toml parser versions
-


### PR DESCRIPTION
## Summary

Adds explicit color control to `stew ci` via `--color`/`--no-color` flags.

## Changes

- `--color`/`--no-color` CLI flag on `stew ci`
- `launch()` resolves color once: explicit flag wins, `None` falls back to TTY + `FORCE_COLOR`/`PY_COLORS`/`CLICOLOR_FORCE` detection
- When color is off, `NO_COLOR=1` is set so subprocesses produce plain output natively — no post-hoc stripping needed

## Testing

```bash
stew ci --color  # force color on
stew ci --no-color  # force color off
```

<img width="785" height="432" alt="image" src="https://github.com/user-attachments/assets/cd3ab88d-ef72-470d-b958-7a1cb64c3b89" />
